### PR TITLE
Update manifest.yml

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -7,7 +7,7 @@ applications:
 - path: .
   name: watson-discovery-ui
   buildpack: sdk-for-nodejs
-  memory: 250M
+  memory: 245M
   instances: 1
   random-route: false
   services:


### PR DESCRIPTION
Decreased memory in order to maintain the lite account memory limit on Watson Discover service.